### PR TITLE
Glyph detection

### DIFF
--- a/code/configs/auto.json
+++ b/code/configs/auto.json
@@ -1,17 +1,10 @@
 {
     "GLOBAL" : {
-        "OBSERVATION_MODE" : true
+        "OBSERVATION_MODE" : false
     },
     "CAMERA_STREAM": {
         "INPUT_WIDTH": 320,
         "INPUT_HEIGHT": 240,
-        "PROCESS_WIDTH": 320
+        "PROCESS_WIDTH": 160
     },
-    "OBJECT_TRACKER": {
-        "TRACK_Kp": 0.22,
-        "TRACK_TauI": 3.9,
-	"TRACK_TauD" : 0.0,
-        "TRACK_SPEED_LIMIT_X": 60,
-        "TRACK_SPEED_LIMIT_Y": 45
-    }
 }

--- a/code/include/camera_stream.h
+++ b/code/include/camera_stream.h
@@ -54,6 +54,20 @@ namespace picopter {
         /** Real-world location (lat/lon/alt) **/
         navigation::Coord3D location;
     } ObjectInfo;
+    
+    /**
+     * Holds information about a glyph.
+     */
+    typedef struct CameraGlyph {
+        /** The glyph ID. Should be unique. **/
+        int id;
+        /** The path to the glyph file, if any. **/
+        std::string path;
+        /** Glyph description. **/
+        std::string description;
+        /** The actual glyph image. **/
+        cv::Mat image;
+    } CameraGlyph;
 
     /**
      * Camera class. Uses OpenCV to interact with the camera.
@@ -124,6 +138,8 @@ namespace picopter {
             navigation::Point3D m_arrow;
             /** Detected objects **/
             std::vector<ObjectInfo> m_detected;
+            /** List of glyphs **/
+            std::vector<CameraGlyph> m_glyphs;
             /** Colour lookup thresholding table **/
             uint8_t m_lookup_threshold[THRESH_SIZE][THRESH_SIZE][THRESH_SIZE];
 
@@ -134,6 +150,8 @@ namespace picopter {
 #ifdef IS_ON_PI
             omxcv::OmxCv *m_enc;
 #endif
+
+            void LoadGlyphs(Options *opts);
 
             void ProcessImages(void);
             void DrawFramerate(cv::Mat& img);
@@ -147,9 +165,9 @@ namespace picopter {
             bool CentreOfMass(cv::Mat& src, cv::Mat& threshold);
             int ConnectedComponents(cv::Mat& src, cv::Mat& threshold);
             bool CamShift(cv::Mat& src, cv::Mat& threshold);
-            bool CannyGlyphDetection(cv::Mat& src, cv::Mat& proc, cv::Mat& templ);
-            bool ThresholdingGlyphDetection(cv::Mat& src, cv::Mat& proc, cv::Mat& templ);
-            bool GlyphContourDetection(cv::Mat& src, std::vector<std::vector<cv::Point>> contours, cv::Mat &templ) ;
+            bool CannyGlyphDetection(cv::Mat& src, cv::Mat& proc);
+            bool ThresholdingGlyphDetection(cv::Mat& src, cv::Mat& proc);
+            bool GlyphContourDetection(cv::Mat& src, std::vector<std::vector<cv::Point>> contours) ;
 
             /** Copy constructor (disabled) **/
             CameraStream(const CameraStream &other);

--- a/code/include/camera_stream.h
+++ b/code/include/camera_stream.h
@@ -172,7 +172,7 @@ namespace picopter {
             bool CamShift(cv::Mat& src, cv::Mat& threshold);
             bool CannyGlyphDetection(cv::Mat& src, cv::Mat& proc);
             bool ThresholdingGlyphDetection(cv::Mat& src, cv::Mat& proc);
-            bool GlyphContourDetection(cv::Mat& src, std::vector<std::vector<cv::Point>> contours) ;
+            bool GlyphContourDetection(cv::Mat& src, std::vector<std::vector<cv::Point>> contours);
 
             /** Copy constructor (disabled) **/
             CameraStream(const CameraStream &other);

--- a/code/include/camera_stream.h
+++ b/code/include/camera_stream.h
@@ -10,6 +10,7 @@
 #include "opts.h"
 #include "common.h"
 #include "navigation.h"
+#include "flightboard.h" //For HUDInfo
 #include <opencv2/opencv.hpp>
 #ifdef IS_ON_PI
 #  include "omxcv.h"
@@ -96,6 +97,8 @@ namespace picopter {
 
             void GetConfig(Options *config);
             void SetConfig(Options *config);
+            
+            void SetHUDInfo(HUDInfo *hud);
 
             void DoAutoLearning(void);
 
@@ -134,6 +137,8 @@ namespace picopter {
             bool m_save_photo;
             /** The path to store the snapshot to **/
             std::string m_save_filename;
+            /** The current HUD info. **/
+            HUDInfo m_hud;
             /** Arrow indicating movement **/
             navigation::Point3D m_arrow;
             /** Detected objects **/
@@ -154,7 +159,7 @@ namespace picopter {
             void LoadGlyphs(Options *opts);
 
             void ProcessImages(void);
-            void DrawFramerate(cv::Mat& img);
+            void DrawHUD(cv::Mat& img);
             void DrawCrosshair(cv::Mat& img, cv::Point centre, const cv::Scalar& colour, int size);
             void DrawTrackingArrow(cv::Mat& img);
 

--- a/code/include/camera_stream.h
+++ b/code/include/camera_stream.h
@@ -65,6 +65,8 @@ namespace picopter {
                 MODE_COM = 1,
                 MODE_CAMSHIFT = 2,
                 MODE_CONNECTED_COMPONENTS = 3,
+                MODE_CANNY_GLYPH = 4,
+                MODE_THRESH_GLYPH = 5,
                 MODE_LEARN_COLOUR = 999
             } CameraMode;
 
@@ -145,6 +147,9 @@ namespace picopter {
             bool CentreOfMass(cv::Mat& src, cv::Mat& threshold);
             int ConnectedComponents(cv::Mat& src, cv::Mat& threshold);
             bool CamShift(cv::Mat& src, cv::Mat& threshold);
+            bool CannyGlyphDetection(cv::Mat& src, cv::Mat& proc, cv::Mat& templ);
+            bool ThresholdingGlyphDetection(cv::Mat& src, cv::Mat& proc, cv::Mat& templ);
+            bool GlyphContourDetection(cv::Mat& src, std::vector<std::vector<cv::Point>> contours, cv::Mat &templ) ;
 
             /** Copy constructor (disabled) **/
             CameraStream(const CameraStream &other);

--- a/code/include/flightboard.h
+++ b/code/include/flightboard.h
@@ -25,8 +25,8 @@ namespace picopter {
      * extra.
      */
     typedef struct HUDInfo {
-        /** Microseconds since UNIX epoch **/
-        uint64_t unix_time;
+        /** UNIX epoch offset, in seconds **/
+        int64_t unix_time_offset;
         /** Air speed, in m/s **/
         float air_speed;
         /** Ground speed, in m/s **/
@@ -105,8 +105,6 @@ namespace picopter {
             std::mutex m_output_mutex;
             /** Gimbal mutex **/
             std::mutex m_gimbal_mutex;
-            /** HUD mutex **/
-            std::mutex m_hud_mutex;
             /** Message receiving thread **/
             std::thread m_input_thread;
             /** Message sending thread **/
@@ -131,8 +129,6 @@ namespace picopter {
             int m_rel_watchdog;
             /** The current gimbal position **/
             navigation::EulerAngle m_gimbal;
-            /** The current HUD info **/
-            HUDInfo m_hud;
             /** The event handler table **/
             EventHandler m_handler_table[256];
 

--- a/code/include/flightboard.h
+++ b/code/include/flightboard.h
@@ -18,6 +18,33 @@ namespace picopter {
     class GPS;
     /* Forward declaration of the IMU class */
     class IMU;
+    
+    /**
+     * Struct to hold information that might be displayed on a heads-up display.
+     * This is basically the same as the MAVLink VFR_HUD message, plus a bit
+     * extra.
+     */
+    typedef struct HUDInfo {
+        /** Microseconds since UNIX epoch **/
+        uint64_t unix_time;
+        /** Air speed, in m/s **/
+        float air_speed;
+        /** Ground speed, in m/s **/
+        float ground_speed;
+        /** Heading, in degrees **/
+        int16_t  heading;
+        /** Throttle percentage **/
+        uint16_t throttle;
+        /** Altitude above mean-sea level (m) **/
+        float alt_msl;
+        /** Climb rate; m/s **/
+        float climb;
+        
+        /** Position (altitude is above ground) **/
+        navigation::Coord3D pos;
+        /** Status message **/
+        std::string status1;
+    } HUDInfo;
 
     /**
      * Controls the actuation of the hexacopter.
@@ -33,6 +60,7 @@ namespace picopter {
             GPS* GetGPSInstance();
             IMU* GetIMUInstance();
             void GetGimbalPose(navigation::EulerAngle *p);
+            void GetLatestHUD(HUDInfo *i);
             
             bool IsAutoMode();
             bool IsRTL();
@@ -77,6 +105,8 @@ namespace picopter {
             std::mutex m_output_mutex;
             /** Gimbal mutex **/
             std::mutex m_gimbal_mutex;
+            /** HUD mutex **/
+            std::mutex m_hud_mutex;
             /** Message receiving thread **/
             std::thread m_input_thread;
             /** Message sending thread **/
@@ -101,6 +131,8 @@ namespace picopter {
             int m_rel_watchdog;
             /** The current gimbal position **/
             navigation::EulerAngle m_gimbal;
+            /** The current HUD info **/
+            HUDInfo m_hud;
             /** The event handler table **/
             EventHandler m_handler_table[256];
 

--- a/code/include/flightcontroller.h
+++ b/code/include/flightcontroller.h
@@ -129,6 +129,8 @@ namespace picopter {
             
             /** Indicates if all operations should be stopped. **/
             std::atomic<bool> m_stop;
+            /** Indicates when the flight controller should shutdown. **/
+            std::atomic<bool> m_quit;
             /** Holds the current state of the flight controller. **/
             std::atomic<ControllerState> m_state;
             /** Holds the current task that is being run. **/
@@ -137,9 +139,15 @@ namespace picopter {
             std::future<void> m_task_thread;
             /** The mutex used to control the currently run task. **/
             std::mutex m_task_mutex;
+            /** Secondary mutex to control flight controller modifications. **/
+            std::mutex m_control_mutex;
+            /** HUD updater thread **/
+            std::thread m_hud_thread;
             /** The current task **/
             std::shared_ptr<FlightTask> m_task;
             
+            /** HUD Loop updater **/
+            void HUDLoop();
             /** Update the current state **/
             ControllerState SetCurrentState(ControllerState state);
             /** Copy constructor (disabled) **/

--- a/code/include/flightcontroller.h
+++ b/code/include/flightcontroller.h
@@ -141,13 +141,13 @@ namespace picopter {
             std::mutex m_task_mutex;
             /** Secondary mutex to control flight controller modifications. **/
             std::mutex m_control_mutex;
-            /** HUD updater thread **/
-            std::thread m_hud_thread;
             /** The current task **/
             std::shared_ptr<FlightTask> m_task;
+            /** HUD info **/
+            HUDInfo m_hud;
             
             /** HUD Loop updater **/
-            void HUDLoop();
+            void HUDParser(const mavlink_message_t *msg);
             /** Update the current state **/
             ControllerState SetCurrentState(ControllerState state);
             /** Copy constructor (disabled) **/

--- a/code/include/opts.h
+++ b/code/include/opts.h
@@ -7,12 +7,17 @@
 #define _PICOPTERX_OPT_H
 
 namespace picopter {
+    /** List parsing callback function **/
+    typedef void (*ListParser)(const void *val, void *closure);
+    
     /**
      * Provides methods to persistently store and retrieve options.
      * This class is not thread safe.
      */
     class Options {
         public:
+            static void* GetValue(void *d, const char *key);
+            
             Options();
             Options(const char *data, bool is_serialised=false);
             Options(const char *file, const char *json_string);
@@ -25,6 +30,8 @@ namespace picopter {
             bool GetBool(const char *key, bool otherwise = false);
             const char* GetString(const char *key, const char *otherwise = "");
             double GetReal(const char *key, double otherwise = 0.0f);
+            
+            void GetList(const char *key, void *closure, ListParser callback);
 
             bool GetInt(const char *key, int *value);
             bool GetInt(const char *key, int *value, int min, int max);

--- a/code/src/base/CMakeLists.txt
+++ b/code/src/base/CMakeLists.txt
@@ -16,6 +16,7 @@ set (SOURCE
 	 flightcontroller.cpp
 	 PID.cpp
 	 camera_stream.cpp
+	 camera_glyphs.cpp
 	 mavcommsserial.cpp
 	 mavcommstcp.cpp
 	 lidar.cpp

--- a/code/src/base/camera_glyphs.cpp
+++ b/code/src/base/camera_glyphs.cpp
@@ -1,0 +1,186 @@
+/**
+ * @file camera_glyphs.cpp
+ * @brief Glyph detection code.
+ * @author Jeremy Tan
+ * Loosely based on:
+ * https://rdmilligan.wordpress.com/2015/07/19/glyph-recognition-using-opencv-and-python/
+ */
+
+#include "common.h"
+#include "camera_stream.h"
+
+using picopter::CameraStream;
+
+/**
+ * Descending order comparator function for sorting contours.
+ * @param [in] a Contour 1.
+ * @param [in] b Contour 2.
+ * @return Comparator value.
+ */
+static bool ContourSort(const std::vector<cv::Point> &a, const std::vector<cv::Point> &b) {
+    return cv::contourArea(b) < cv::contourArea(a);
+}
+
+/**
+ * Order the four corners of the quadrilateral.
+ * Note that this doesn't always work, but it's fast and good enough for
+ * trying to detect a square's points.
+ * A better method probably involves computing the convex hull of the points
+ * but OpenCV's function doesn't seem to return them in any particular order.
+ * @param [in] pts The points to be ordered.
+ * @return The ordered points (top-left, top-right, bottom-left, bottom-right).
+ */
+static std::vector<cv::Point2f> OrderPoints(std::vector<cv::Point>& pts) {
+    assert(pts.size() == 4);
+    std::vector<cv::Point2f> ret(4);
+    int p1=0,p2=0,p3=0,p4=0;
+    
+    for (int i = 0; i < 4; i++) {
+        int sum = pts[i].x + pts[i].y;
+        int diff = pts[i].y - pts[i].x;
+        
+        if (sum < (pts[p1].x + pts[p1].y))
+            p1 = i;
+        if (sum > (pts[p3].x + pts[p3].y))
+            p3 = i;
+        if (diff < (pts[p2].y - pts[p2].x))
+            p2 = i;
+        if (diff > (pts[p4].y - pts[p4].x))
+            p4 = i;
+    }
+    
+    ret[0] = pts[p1]; ret[1] = pts[p2]; ret[2] = pts[p3]; ret[3] = pts[p4];
+    return ret;
+}
+
+/**
+ * Use the contour points to warp the quad into a top-down perspective.
+ * This function will only warp at least somewhat square quads.
+ * @param [in] in The input frame.
+ * @param [out] out The output frame.
+ * @param [in] pts The four points that define the quad.
+ * @return true iff it was warped.
+ */
+static bool WarpPerspective(cv::Mat &in, cv::Mat &out, std::vector<cv::Point> &pts) {
+    std::vector<cv::Point2f> src = std::move(OrderPoints(pts));
+    cv::Rect b = std::move(cv::boundingRect(src));
+    float ratio = static_cast<float>(b.width)/b.height;
+    
+    //Discard largely non-square images
+    if (ratio < 0.4 || ratio > 1.6)
+        return false;
+    
+    std::vector<cv::Point2f> dst{cv::Point2f(0,0), cv::Point2f(b.width-1, 0),
+        cv::Point2f(b.width-1,b.height-1), cv::Point2f(0, b.height-1)};
+    cv::Mat trn = std::move(cv::getPerspectiveTransform(src, dst));
+    cv::warpPerspective(in, out, trn, b.size());
+    
+    return true;
+}
+
+/**
+ * Performs glyph detection on the contour list.
+ * @param [in] src The source image to detect glyphs from.
+ * @param [in] contours The corresponding contour list.
+ * @param [in] templ The glyph template to match against.
+ * @return true iff detected.
+ */
+bool CameraStream::GlyphContourDetection(cv::Mat& src, std::vector<std::vector<cv::Point>> contours, cv::Mat &templ) {
+    for (size_t i = 0; i < 2 && i < contours.size(); i++) {
+        double perimiter = cv::arcLength(contours[i], true);
+        std::vector<cv::Point> approx;
+        cv::approxPolyDP(contours[i], approx, 0.01*perimiter, true);
+        
+        if (approx.size() == 4) { //We probably have a quad.
+            cv::Mat quad;
+            if (WarpPerspective(src, quad, approx)) {
+                cv::resize(quad, quad, cv::Size(templ.cols, templ.rows));
+                if (m_demo_mode) {
+                    cv::imshow("Test", quad);
+                }
+                
+                //Perform template matching
+                cv::Mat result(1, 1, CV_32FC1);
+                cv::matchTemplate(quad, templ, result, CV_TM_CCORR_NORMED);
+
+                //Get the correlation value
+                double minVal; double maxVal;
+                cv::minMaxLoc(result, &minVal, &maxVal, NULL, NULL, cv::Mat());
+                
+                //Log(LOG_DEBUG, "%.4f", maxVal);
+                //Check goodness of fit.
+                if (maxVal > 0.8)
+                    Log(LOG_DEBUG, "DETECTED! %.2f", maxVal);
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * Perform glyph detection. Potential glyphs are first found using Canny
+ * line detection to detect square objects.
+ * @param [in] src The source image to search for a glyph.
+ * @param [in] proc The process buffer.
+ * @param [in] templ The template glyph.
+ * @return true iff glyph was detected.
+ */
+bool CameraStream::CannyGlyphDetection(cv::Mat& src, cv::Mat& proc, cv::Mat& templ) {
+    cv::Mat gray;
+    //Downscale
+    cv::resize(src, gray, cv::Size(PROCESS_WIDTH, PROCESS_HEIGHT));
+    //Convert to grayscale
+    cv::cvtColor(gray, gray, CV_BGR2GRAY);
+    //Blur it a bit
+    cv::GaussianBlur(gray, gray, cv::Size(5,5), 0);
+    //Apply Canny detection
+    cv::Canny(gray, proc, 100, 200);
+    
+    //Find the contours in the image and sort in descending order of contour area.
+    std::vector<std::vector<cv::Point>> contours;
+    cv::findContours(proc, contours, cv::RETR_LIST, cv::CHAIN_APPROX_SIMPLE);
+    std::sort(contours.begin(), contours.end(), ContourSort);
+    
+    return GlyphContourDetection(gray, contours, templ);
+}
+
+/**
+ * Perform glyph detection. Potential glyphs are found by using colour
+ * thresholding to detect square objects. (Contours are detected in the
+ * same manner used for the connected components algorithm).
+ * 
+ * @param [in] src The source image to search for a glyph.
+ * @param [in] threshold The process buffer.
+ * @param [in] templ The template glyph.
+ * @return true iff glyph was detected.
+ */
+bool CameraStream::ThresholdingGlyphDetection(cv::Mat& src, cv::Mat& threshold, cv::Mat& templ) {
+    //Threshold the image.
+    Threshold(src, threshold, PROCESS_WIDTH);
+
+    //Blur, dilate and erode the image
+    cv::Mat elementDilate(8, 8, CV_8U, cv::Scalar(255));
+    cv::Mat elementErode(8, 8, CV_8U, cv::Scalar(255));
+
+    cv::dilate(threshold, threshold, elementDilate);
+    cv::erode(threshold, threshold, elementErode);
+
+    if (m_demo_mode) {
+        cv::imshow("Thresholded image", threshold);
+        cv::waitKey(1);
+    }
+
+    //Find the contours (connected components)
+    std::vector<std::vector<cv::Point>> contours;
+    cv::findContours(threshold, contours, cv::RETR_LIST, cv::CHAIN_APPROX_SIMPLE);
+    std::sort(contours.begin(), contours.end(), ContourSort);
+    //Translate from threshold point space back into source point space.
+    //I'm sure there's an OpenCV way to do this with matrices, but whatever.
+    for (size_t i = 0; i < 2 && i < contours.size(); i++) {
+        for (size_t j = 0; j < contours[i].size(); j++) {
+            contours[i][j].x *= PIXEL_SKIP;
+            contours[i][j].y *= PIXEL_SKIP;
+        }
+    }
+    return GlyphContourDetection(src, contours, templ);
+}

--- a/code/src/base/camera_stream.cpp
+++ b/code/src/base/camera_stream.cpp
@@ -1,10 +1,11 @@
 /**
  * @file camera_stream.cpp
- * @brief Camera interaction functions.
+ * @brief Camera interaction functions. Monster class for camera processing.
  */
 
 #include "common.h"
 #include "camera_stream.h"
+#include "flightboard.h"
 
 #define BLACK 0
 #define WHITE 255
@@ -37,6 +38,7 @@ CameraStream::CameraStream(Options *opts)
 , m_fps(-1)
 , m_show_backend(false)
 , m_save_photo(false)
+, m_hud{}
 , m_arrow{}
 {
     Options clear;
@@ -216,6 +218,15 @@ void CameraStream::SetConfig(Options *config) {
 }
 
 /**
+ * Sets the heads-up display info.
+ * @param [in] hud The HUD info.
+ */
+void CameraStream::SetHUDInfo(HUDInfo *hud) {
+    std::lock_guard<std::mutex> lock(m_aux_mutex);
+    m_hud = *hud;
+}
+
+/**
  * Perform camera auto learning.
  */
 void CameraStream::DoAutoLearning() {
@@ -328,8 +339,8 @@ void CameraStream::ProcessImages() {
         // Draw an arrow on the image (for displaying where it wants to go for object tracking)
         DrawTrackingArrow(image);
 
-        //Display the frame rate
-        DrawFramerate(image);
+        //Overlay the HUD
+        DrawHUD(image);
 
         //Are we in demo mode? If so, display the image on the screen.
         //Trying to do this when no X server is available will crash the program.
@@ -379,15 +390,52 @@ double CameraStream::GetFramerate() {
 }
 
 /**
- * Draws the current frame rate on the image.
- * @param [in] img The image to draw the frame rate onto.
+ * Draws a heads-up display onto the frame.
+ * @param [in] img The image to draw the HUD onto.
  */
-void CameraStream::DrawFramerate(cv::Mat& img) {
+void CameraStream::DrawHUD(cv::Mat& img) {
+    std::unique_lock<std::mutex> lock(m_aux_mutex);
+    HUDInfo hud = m_hud;
+    lock.unlock();
+    
     char string_buf[128];
-
+    time_t ts = static_cast<time_t>(hud.unix_time / 1000000); 
+    struct tm tsp;
+    
+    //Enter the time
+    localtime_r(&ts, &tsp);
+    strftime(string_buf, sizeof(string_buf), "%H:%M:%S", &tsp);
+    cv::putText(img, string_buf, cv::Point(70*img.cols/100, 5*img.rows/100),
+        cv::FONT_HERSHEY_SIMPLEX, 0.34, cv::Scalar(255, 255, 255), 1, 8);
+    strftime(string_buf, sizeof(string_buf), "%d-%m-%Y", &tsp);
+    cv::putText(img, string_buf, cv::Point(70*img.cols/100, 10*img.rows/100),
+        cv::FONT_HERSHEY_SIMPLEX, 0.4, cv::Scalar(255, 255, 255), 1, 8);
+    //Enter the FPS
     sprintf(string_buf, "%3.4f fps", m_fps);
-    cv::putText(img, string_buf, cv::Point(30*img.cols/100, 90*img.rows/100),
-        cv::FONT_HERSHEY_SIMPLEX, 0.8, cv::Scalar(255, 255, 255), 1, 8);
+    cv::putText(img, string_buf, cv::Point(70*img.cols/100, 15*img.rows/100),
+        cv::FONT_HERSHEY_SIMPLEX, 0.4, cv::Scalar(255, 255, 255), 1, 8);
+    
+    //Enter the position
+    sprintf(string_buf, "%.7f, %.7f", hud.pos.lat, hud.pos.lon);
+    cv::putText(img, string_buf, cv::Point(5*img.cols/100, 5*img.rows/100),
+        cv::FONT_HERSHEY_SIMPLEX, 0.4, cv::Scalar(255, 255, 255), 1, 8);
+    //Enter the altitude and climb rate
+    sprintf(string_buf, "%.1fm, %.1fm/s", hud.pos.alt, hud.climb);
+    cv::putText(img, string_buf, cv::Point(5*img.cols/100, 10*img.rows/100),
+        cv::FONT_HERSHEY_SIMPLEX, 0.4, cv::Scalar(255, 255, 255), 1, 8);
+    //Enter the heading and throttle
+    sprintf(string_buf, "%03d deg, %d%%", hud.heading, hud.throttle);
+    cv::putText(img, string_buf, cv::Point(5*img.cols/100, 15*img.rows/100),
+        cv::FONT_HERSHEY_SIMPLEX, 0.4, cv::Scalar(255, 255, 255), 1, 8);
+    //Enter the ground speed and air speed.
+    sprintf(string_buf, "GS: %.1fm/s AS:%.1f m/s", hud.ground_speed, hud.air_speed);
+    cv::putText(img, string_buf, cv::Point(5*img.cols/100, 20*img.rows/100),
+        cv::FONT_HERSHEY_SIMPLEX, 0.4, cv::Scalar(255, 255, 255), 1, 8);
+        
+    if (hud.status1.size()) {
+        cv::putText(img, hud.status1, cv::Point(5*img.cols/100, 92*img.rows/100),
+        cv::FONT_HERSHEY_SIMPLEX, 0.4, cv::Scalar(255, 255, 255), 1, 8);
+    }
 }
 
 /**

--- a/code/src/base/camera_stream.cpp
+++ b/code/src/base/camera_stream.cpp
@@ -260,6 +260,10 @@ void CameraStream::ProcessImages() {
     static const std::vector<int> saveparams = {CV_IMWRITE_JPEG_QUALITY, 90};
     int frame_counter = 0, frame_duration = 0;
     auto sampling_start = steady_clock::now();
+    cv::Mat tmp = cv::imread("glyph1.png");
+    cv::resize(tmp, tmp, cv::Size(100,100));
+    //cv::cvtColor(tmp, tmp, CV_BGR2GRAY);
+    cv::GaussianBlur(tmp,tmp, cv::Size(7,7), 0);
 
     while (!m_stop) {
         std::unique_lock<std::mutex> lock(m_worker_mutex, std::defer_lock);
@@ -312,6 +316,12 @@ void CameraStream::ProcessImages() {
                     }
                 }
                 break;
+            case MODE_CANNY_GLYPH:
+                CannyGlyphDetection(image, backend, tmp);
+            break;
+            case MODE_THRESH_GLYPH:
+                ThresholdingGlyphDetection(image, backend, tmp);
+            break;
         }
 
         DrawCrosshair(image, cv::Point(image.cols/2, image.rows/2),

--- a/code/src/base/camera_stream.cpp
+++ b/code/src/base/camera_stream.cpp
@@ -97,7 +97,7 @@ CameraStream::CameraStream(Options *opts)
     std::string f = GenerateFilename(
         PICOPTER_HOME_LOCATION "/videos", "save", ".mkv");
     Log(LOG_INFO, "Saving video to %s", f.c_str());
-    m_enc = new OmxCv(f.c_str(), INPUT_WIDTH, INPUT_HEIGHT, 800);
+    m_enc = new OmxCv(f.c_str(), INPUT_WIDTH, INPUT_HEIGHT, (700 * INPUT_WIDTH)/320);
 #endif
 
     //Start the worker thread.
@@ -327,10 +327,20 @@ void CameraStream::ProcessImages() {
                 }
                 break;
             case MODE_CANNY_GLYPH:
-                CannyGlyphDetection(image, backend);
+                if (CannyGlyphDetection(image, backend)) {
+                    for(size_t i=0; i < m_detected.size(); i++) {
+                        cv::rectangle(image, m_detected[i].bounds.tl(),
+                            m_detected[i].bounds.br(), m_colours[i%m_colours.size()]);
+                    }
+                }
             break;
             case MODE_THRESH_GLYPH:
-                ThresholdingGlyphDetection(image, backend);
+                if (ThresholdingGlyphDetection(image, backend)) {
+                    for(size_t i=0; i < m_detected.size(); i++) {
+                        cv::rectangle(image, m_detected[i].bounds.tl(),
+                            m_detected[i].bounds.br(), m_colours[i%m_colours.size()]);
+                    }
+                }
             break;
         }
 

--- a/code/src/base/camera_stream.cpp
+++ b/code/src/base/camera_stream.cpp
@@ -44,6 +44,9 @@ CameraStream::CameraStream(Options *opts)
         opts = &clear;
     }
 
+    //Load the glyphs, if any.
+    LoadGlyphs(opts);
+    
     //Set the input/processing/streaming width parameters
     opts->SetFamily("CAMERA_STREAM");
     INPUT_WIDTH   = opts->GetInt("INPUT_WIDTH", 320);
@@ -260,10 +263,6 @@ void CameraStream::ProcessImages() {
     static const std::vector<int> saveparams = {CV_IMWRITE_JPEG_QUALITY, 90};
     int frame_counter = 0, frame_duration = 0;
     auto sampling_start = steady_clock::now();
-    cv::Mat tmp = cv::imread("glyph1.png");
-    cv::resize(tmp, tmp, cv::Size(100,100));
-    //cv::cvtColor(tmp, tmp, CV_BGR2GRAY);
-    cv::GaussianBlur(tmp,tmp, cv::Size(7,7), 0);
 
     while (!m_stop) {
         std::unique_lock<std::mutex> lock(m_worker_mutex, std::defer_lock);
@@ -317,10 +316,10 @@ void CameraStream::ProcessImages() {
                 }
                 break;
             case MODE_CANNY_GLYPH:
-                CannyGlyphDetection(image, backend, tmp);
+                CannyGlyphDetection(image, backend);
             break;
             case MODE_THRESH_GLYPH:
-                ThresholdingGlyphDetection(image, backend, tmp);
+                ThresholdingGlyphDetection(image, backend);
             break;
         }
 

--- a/code/src/base/camera_stream.cpp
+++ b/code/src/base/camera_stream.cpp
@@ -399,7 +399,7 @@ void CameraStream::DrawHUD(cv::Mat& img) {
     lock.unlock();
     
     char string_buf[128];
-    time_t ts = static_cast<time_t>(hud.unix_time / 1000000); 
+    time_t ts = time(NULL) + hud.unix_time_offset;
     struct tm tsp;
     
     //Enter the time

--- a/code/src/base/flightboard.cpp
+++ b/code/src/base/flightboard.cpp
@@ -40,7 +40,6 @@ FlightBoard::FlightBoard(Options *opts)
 , m_is_armed{false}
 , m_rel_watchdog(0)
 , m_gimbal{}
-, m_hud{}
 , m_handler_table{}
 {
     if (opts) {
@@ -111,15 +110,6 @@ void FlightBoard::GetGimbalPose(EulerAngle *p) {
 }
 
 /**
- * Retrieve the latest HUD information.
- * @param [in] i The location to store HUD info.
- */
-void FlightBoard::GetLatestHUD(HUDInfo *i) {
-    std::lock_guard<std::mutex> lock(m_hud_mutex);
-    *i = m_hud;
-}
-
-/**
  * Input loop to process MAVLink messages received from the copter (Pixhawk).
  */
 void FlightBoard::InputLoop() {
@@ -140,11 +130,12 @@ void FlightBoard::InputLoop() {
                         m_is_in_air = (heartbeat.system_status == MAV_STATE_ACTIVE);
                         m_is_armed = static_cast<bool>(
                             heartbeat.base_mode & MAV_MODE_FLAG_SAFETY_ARMED);
-                        LogSimple(LOG_DEBUG, "Heartbeat! Mode: %d, %d, %d, %d, %d", 
-                        heartbeat.type, heartbeat.base_mode, heartbeat.custom_mode, 
-                        heartbeat.system_status, (int)m_is_auto_mode);
+                        //LogSimple(LOG_DEBUG, "Heartbeat! Mode: %d, %d, %d, %d, %d", 
+                        //heartbeat.type, heartbeat.base_mode, heartbeat.custom_mode, 
+                        //heartbeat.system_status, (int)m_is_auto_mode);
                         
                         if (m_last_heartbeat >= m_heartbeat_timeout) {
+                            mavlink_request_data_stream_t stream{};
                             mavlink_message_t smsg;
 
                             m_system_id = msg.sysid;
@@ -152,21 +143,36 @@ void FlightBoard::InputLoop() {
                             Log(LOG_INFO, "Initialisation: sysid: %d, compid: %d",
                                 msg.sysid, msg.compid);
                             
-                            //10 Hz update rate
-                            mavlink_msg_request_data_stream_pack(
-                                m_system_id, m_flightboard_id, &smsg,
-                                msg.sysid, msg.compid, MAV_DATA_STREAM_ALL, 10, 1);
-                            //Log(LOG_DEBUG, "Sending data request");
+                            stream.target_system = m_system_id;
+                            stream.target_component = m_component_id;
+                            stream.start_stop = 1;
+                            stream.req_message_rate = 6;
+                            
+                            //GPS data at 6Hz
+                            stream.req_stream_id = MAV_DATA_STREAM_POSITION;
+                            mavlink_msg_request_data_stream_encode(
+                                m_system_id, m_flightboard_id, &smsg, &stream);
+                            m_link->WriteMessage(&smsg);
+                            //IMU data at 6Hz
+                            stream.req_stream_id = MAV_DATA_STREAM_EXTRA1;
+                            mavlink_msg_request_data_stream_encode(
+                                m_system_id, m_flightboard_id, &smsg, &stream);
+                            m_link->WriteMessage(&smsg);
+                            //HUD data at 1Hz
+                            stream.req_stream_id = MAV_DATA_STREAM_EXTRA2;
+                            stream.req_message_rate = 1;
+                            mavlink_msg_request_data_stream_encode(
+                                m_system_id, m_flightboard_id, &smsg, &stream);
+                            m_link->WriteMessage(&smsg);
+                            //Time at 1Hz - only for syncing w/ copter (GPS).
+                            stream.req_stream_id = MAV_DATA_STREAM_EXTRA3;
+                            stream.req_message_rate = 1;
+                            mavlink_msg_request_data_stream_encode(
+                                m_system_id, m_flightboard_id, &smsg, &stream);
                             m_link->WriteMessage(&smsg);
                         }
                         last_heartbeat = steady_clock::now();
                     }
-                } break;
-                case MAVLINK_MSG_ID_SYSTEM_TIME: {
-                    mavlink_system_time_t tm;
-                    mavlink_msg_system_time_decode(&msg, &tm);
-                    std::lock_guard<std::mutex> lock(m_hud_mutex);
-                    m_hud.unix_time = tm.time_unix_usec;
                 } break;
                 //case MAVLINK_MSG_ID_SYS_STATUS: {
                 //    mavlink_sys_status_t status;
@@ -190,17 +196,6 @@ void FlightBoard::InputLoop() {
                     m_gimbal.roll = mnt.pointing_b/100.0;
                     m_gimbal.yaw = mnt.pointing_c/100.0;
                     //Log(LOG_DEBUG, "GOT MOUNT! %1f, %.1f, %.1f", m_gimbal.pitch, m_gimbal.roll, m_gimbal.yaw);
-                } break;
-                case MAVLINK_MSG_ID_VFR_HUD: {
-                    mavlink_vfr_hud_t vfr;
-                    mavlink_msg_vfr_hud_decode(&msg, &vfr);
-                    std::lock_guard<std::mutex> lock(m_hud_mutex);
-                    m_hud.air_speed = vfr.airspeed;
-                    m_hud.ground_speed = vfr.groundspeed;
-                    m_hud.heading = vfr.heading;
-                    m_hud.throttle = vfr.throttle;
-                    m_hud.alt_msl = vfr.alt;
-                    m_hud.climb = vfr.climb;
                 } break;
             }
             

--- a/code/src/base/lidar.cpp
+++ b/code/src/base/lidar.cpp
@@ -57,7 +57,6 @@ int Lidar::GetLatest() {
 }
 
 void Lidar::Worker() {
-    
     while (!m_stop) {
         while (wiringPiI2CWriteReg8(m_fd, 
             MEASURE_REGISTER, MEASURE_VALUE) < 0 && !m_stop) {
@@ -71,7 +70,7 @@ void Lidar::Worker() {
             Log(LOG_DEBUG, "Error reading from LIDAR.");
         } else {
             m_distance = (high<<8) | (low);
-            Log(LOG_DEBUG, "DIST: %d", m_distance.load());
+            //Log(LOG_DEBUG, "DIST: %d", m_distance.load());
         }
         
         sleep_for(milliseconds(50)); //20Hz update speed

--- a/code/src/base/mavcommsserial.cpp
+++ b/code/src/base/mavcommsserial.cpp
@@ -123,7 +123,7 @@ MAVCommsSerial::~MAVCommsSerial() {
  */
 bool MAVCommsSerial::ReadMessage(mavlink_message_t *ret) {
     std::lock_guard<std::mutex> lock(m_io_mutex);
-    struct timeval timeout = {2,0}; //2 second timeout
+    struct timeval timeout = {3,0}; //3 second timeout
     mavlink_status_t status;
     bool received;
     uint8_t cp;

--- a/code/src/base/mavcommstcp.cpp
+++ b/code/src/base/mavcommstcp.cpp
@@ -57,7 +57,7 @@ MAVCommsTCP::~MAVCommsTCP() {
  * @return true iff a message was read.
  */
 bool MAVCommsTCP::ReadMessage(mavlink_message_t *ret) {
-    struct timeval timeout = {2,0}; //2 second timeout
+    struct timeval timeout = {5,0}; //5 second timeout
     mavlink_status_t status;
     bool received;
     uint8_t cp;

--- a/code/src/modules/utility.cpp
+++ b/code/src/modules/utility.cpp
@@ -56,6 +56,8 @@ void UtilityModule::Run(FlightController *fc, void *opts) {
             while (!fc->fb->IsArmed() && !fc->CheckForStop()) {
                 fc->Sleep(100);
             }
+            //Wait a while for motor spinup
+            fc->Sleep(300);
             
             if (fc->fb->IsArmed() && !fc->CheckForStop()) {
                 Log(LOG_INFO, "Performing take-off!");

--- a/experiments/camera/glyph.py
+++ b/experiments/camera/glyph.py
@@ -1,0 +1,138 @@
+import numpy as np
+import cv2
+ 
+def order_points(points):
+    '''
+    ordered_points = cv2.convexHull(points)
+    if ordered_points[:,0].shape[0] == 4:
+        print("ORIGINAL", points, "\nORDERED", ordered_points[:,0])
+    return ordered_points[:,0].astype("float32")
+    '''
+    s = points.sum(axis=1)
+    diff = np.diff(points, axis=1)
+     
+    ordered_points = np.zeros((4,2), dtype="float32")
+ 
+    ordered_points[0] = points[np.argmin(s)]
+    ordered_points[2] = points[np.argmax(s)]
+    ordered_points[1] = points[np.argmin(diff)]
+    ordered_points[3] = points[np.argmax(diff)]
+
+    return ordered_points
+ 
+def max_width_height(points):
+ 
+    (tl, tr, br, bl) = points
+ 
+    top_width = np.sqrt(((tr[0] - tl[0]) ** 2) + ((tr[1] - tl[1]) ** 2))
+    bottom_width = np.sqrt(((br[0] - bl[0]) ** 2) + ((br[1] - bl[1]) ** 2))
+    max_width = max(int(top_width), int(bottom_width))
+ 
+    left_height = np.sqrt(((tl[0] - bl[0]) ** 2) + ((tl[1] - bl[1]) ** 2))
+    right_height = np.sqrt(((tr[0] - br[0]) ** 2) + ((tr[1] - br[1]) ** 2))
+    max_height = max(int(left_height), int(right_height))
+ 
+    return (max_width,max_height)
+ 
+def topdown_points(max_width, max_height):
+    return np.array([
+        [0, 0],
+        [max_width-1, 0],
+        [max_width-1, max_height-1],
+        [0, max_height-1]], dtype="float32")
+ 
+def get_topdown_quad(image, src):
+ 
+    # src and dst points
+    src = order_points(src)
+    if src.shape[0] < 4:
+        #Not a quad.
+        return image
+ 
+    (max_width,max_height) = max_width_height(src)
+    dst = topdown_points(max_width, max_height)
+  
+    # warp perspective
+    matrix = cv2.getPerspectiveTransform(src, dst)
+    warped = cv2.warpPerspective(image, matrix, max_width_height(src))
+ 
+    # return top-down quad
+    return warped
+ 
+def add_substitute_quad(image, substitute_quad, dst):
+ 
+    # dst (zero-set) and src points
+    dst = order_points(dst)
+    if dst.shape[0] < 4:
+        return
+     
+    (tl, tr, br, bl) = dst
+    min_x = min(int(tl[0]), int(bl[0]))
+    min_y = min(int(tl[1]), int(tr[1]))
+ 
+    for point in dst:
+        point[0] = point[0] - min_x
+        point[1] = point[1] - min_y
+ 
+    (max_width,max_height) = max_width_height(dst)
+    src = topdown_points(max_width, max_height)
+ 
+    # warp perspective (with white border)
+    substitute_quad = cv2.resize(substitute_quad, (max_width,max_height))
+ 
+    warped = np.zeros((max_height,max_width, 3), np.uint8)
+    warped[:,:,:] = 255
+ 
+    matrix = cv2.getPerspectiveTransform(src, dst)
+    cv2.warpPerspective(substitute_quad, matrix, (max_width,max_height), warped, borderMode=cv2.BORDER_TRANSPARENT)
+ 
+    # add substitute quad
+    image[min_y:min_y + max_height, min_x:min_x + max_width] = warped
+ 
+    return image
+ 
+def get_glyph_pattern(image, black_threshold, white_threshold):
+ 
+    # collect pixel from each cell (left to right, top to bottom)
+    cells = []
+     
+    cell_half_width = int(round(image.shape[1] / 10.0))
+    cell_half_height = int(round(image.shape[0] / 10.0))
+ 
+    row1 = cell_half_height*3
+    row2 = cell_half_height*5
+    row3 = cell_half_height*7
+    col1 = cell_half_width*3
+    col2 = cell_half_width*5
+    col3 = cell_half_width*7
+ 
+    cells.append(image[row1, col1])
+    cells.append(image[row1, col2])
+    cells.append(image[row1, col3])
+    cells.append(image[row2, col1])
+    cells.append(image[row2, col2])
+    cells.append(image[row2, col3])
+    cells.append(image[row3, col1])
+    cells.append(image[row3, col2])
+    cells.append(image[row3, col3])
+ 
+    # threshold pixels to either black or white
+    for idx, val in enumerate(cells):
+        if val < black_threshold:
+            cells[idx] = 0
+        elif val > white_threshold:
+            cells[idx] = 1
+        else:
+            return None
+ 
+    return cells
+ 
+def resize_image(image, new_size):
+    ratio = new_size / image.shape[1]
+    return cv2.resize(image,(int(new_size),int(image.shape[0]*ratio)))
+ 
+def rotate_image(image, angle):
+    (h, w) = image.shape[:2]
+    center = (w / 2, h / 2)
+    rotation_matrix = cv2.getRotationMatrix2D(center, angle, 1.0)
+    return cv2.warpAffine(image, rotation_matrix, (w, h))

--- a/experiments/camera/glyph1.svg
+++ b/experiments/camera/glyph1.svg
@@ -15,7 +15,10 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="glyph1.svg">
+   sodipodi:docname="glyph1.svg"
+   inkscape:export-filename="C:\Users\tanjj\Documents\2015\MCTX4421\picopterx\experiments\camera\glyph1.png"
+   inkscape:export-xdpi="22.5"
+   inkscape:export-ydpi="22.5">
   <defs
      id="defs4" />
   <sodipodi:namedview
@@ -26,7 +29,7 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="0.7"
-     inkscape:cx="144.9846"
+     inkscape:cx="-86.443971"
      inkscape:cy="180.76948"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
@@ -48,7 +51,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/experiments/camera/glyph1.svg
+++ b/experiments/camera/glyph1.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="112.88889mm"
+   height="112.88889mm"
+   viewBox="0 0 399.99998 399.99998"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="glyph1.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.7"
+     inkscape:cx="144.9846"
+     inkscape:cy="180.76948"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1366"
+     inkscape:window-height="705"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-105.71304,-235.2206)">
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.99750626;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4136"
+       width="400"
+       height="400"
+       x="105.71304"
+       y="235.2206" />
+    <g
+       id="g4170"
+       transform="translate(0,-0.00494385)">
+      <rect
+         y="293.79697"
+         x="265.71304"
+         height="80"
+         width="80"
+         id="rect4138"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.98765427;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <g
+         transform="translate(0.00492096,0)"
+         id="g4166">
+        <rect
+           y="496.65411"
+           x="361.42242"
+           height="80"
+           width="80"
+           id="rect4140"
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.98765427;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.98765427;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect4142"
+           width="80"
+           height="80"
+           x="169.99382"
+           y="496.65411" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/experiments/camera/glyphrun.py
+++ b/experiments/camera/glyphrun.py
@@ -1,0 +1,114 @@
+from __future__ import print_function
+import cv2
+from glyph import *
+from threading import Thread
+import signal
+import sys
+import traceback
+
+
+class Webcam:
+    def __init__(self):
+        self.video_capture = cv2.VideoCapture(0)
+        self.current_frame = self.video_capture.read()[1]
+        self.destroy = False
+          
+    # create thread for capturing images
+    def start(self):
+        self.thread = Thread(target=self._update_frame, args=())
+        self.thread.start()
+  
+    def _update_frame(self):
+        while(not self.destroy):
+            self.current_frame = self.video_capture.read()[1]
+                  
+    # get the current frame
+    def get_current_frame(self):
+        return self.current_frame
+ 
+webcam = Webcam()
+webcam.start()
+
+def signal_handler(signal, frame):
+    print("EXITING!")
+    webcam.destroy = True
+    webcam.thread.join()
+    
+    sys.exit(0)
+signal.signal(signal.SIGINT, signal_handler)
+ 
+QUADRILATERAL_POINTS = 4
+SHAPE_RESIZE = 100
+BLACK_THRESHOLD = 100
+WHITE_THRESHOLD = 155
+
+
+if __name__ == "__main__":    
+    try:
+        template = cv2.imread("glyph1.png")
+        scale = 100.0/template.shape[1] #Screw you too, python2.
+        print(scale)
+        template = cv2.resize(template, (100, int(template.shape[0]*scale)))
+        template = cv2.cvtColor(template, cv2.COLOR_BGR2GRAY)
+        template = cv2.GaussianBlur(template, (7,7), 0)
+        template = cv2.threshold(template, BLACK_THRESHOLD, 255, cv2.THRESH_BINARY)[1]
+        #template = cv2.Canny(template, 100, 200)
+        cv2.imshow("TEMPLATE", template)
+        
+        while True:
+            #Capture and convert to grey
+            image = webcam.get_current_frame()
+            gray2 = gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+            #Blur before applying canny edge detection
+            gray = cv2.GaussianBlur(gray, (5,5), 0)
+            edges = cv2.Canny(gray, 100, 200)
+            cv2.imshow('Canny', edges)
+            #cv2.imshow('Original', image)
+            
+            #Find contours in the image (similar to connected components)
+            contours, hierarchy = cv2.findContours(edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+            #Get the 10 largest contours
+            contours = sorted(contours, key=cv2.contourArea, reverse=True)[:10]
+             
+            for contour in contours:
+                #Determine if we're dealing with squares.
+                perimeter = cv2.arcLength(contour, True)
+                approx = cv2.approxPolyDP(contour, 0.01*perimeter, True)
+                 
+                if len(approx) == QUADRILATERAL_POINTS:
+                    topdown_quad = get_topdown_quad(gray2, approx.reshape(4, 2))
+                    
+                    #Discard non-square images by computing the height.
+                    rf = float(SHAPE_RESIZE) / topdown_quad.shape[1]
+                    rh = topdown_quad.shape[0]*rf
+                    if (rh < 50) or (rh > 150): continue
+                    
+                    #Check inside shape to see if it's black.
+                    resized_shape = cv2.resize(topdown_quad, (SHAPE_RESIZE, SHAPE_RESIZE))
+                    #Threshold the image
+                    resized_shape = cv2.threshold(resized_shape, BLACK_THRESHOLD, 255, cv2.THRESH_BINARY)[1]
+                    #if (resized_shape[5,5]): continue
+                   
+                    #Compute the edges of the warped ROI
+                    #edged = cv2.Canny(resized_shape, 100, 200)
+                    edged = resized_shape
+                    
+                    #Perform template matching
+                    result = cv2.matchTemplate(edged, template, cv2.TM_CCORR_NORMED)
+                    (minVal, maxVal, minLoc, maxLoc) = cv2.minMaxLoc(result)
+                    
+                    #Check goodness of fit.
+                    if (maxVal > 0.8):
+                        print("DETECTED!", maxVal)
+                    else:
+                        #print("REJECTED!", maxVal)
+                        pass
+                        
+                    cv2.imshow('test', edged)
+                    
+                    
+            cv2.imshow('Original', image)
+            cv2.waitKey(10)
+    except Exception:
+        print(traceback.format_exc())
+        signal_handler(2, None)

--- a/experiments/camera/glyphtm.py
+++ b/experiments/camera/glyphtm.py
@@ -1,0 +1,37 @@
+from __future__ import print_function
+import cv2
+import numpy as np
+from matplotlib import pyplot as plt
+from glyphrun import *
+import traceback
+
+template = cv2.imread('glyph1.png',0)
+w, h = template.shape[::-1]
+
+# All the 6 methods for comparison in a list
+methods = ['cv2.TM_CCOEFF', 'cv2.TM_CCOEFF_NORMED', 'cv2.TM_CCORR',
+            'cv2.TM_CCORR_NORMED', 'cv2.TM_SQDIFF', 'cv2.TM_SQDIFF_NORMED']
+
+if __name__ == "__main__":
+    try:
+        while True:            
+            #Capture and convert to grey
+            image = webcam.get_current_frame()
+            gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+            
+            method = cv2.TM_CCOEFF
+            res = cv2.matchTemplate(gray, template, method)
+            min_val, max_val, min_loc, max_loc = cv2.minMaxLoc(res)
+            # If the method is TM_SQDIFF or TM_SQDIFF_NORMED, take minimum
+            if method in [cv2.TM_SQDIFF, cv2.TM_SQDIFF_NORMED]:
+                top_left = min_loc
+            else:
+                top_left = max_loc
+            bottom_right = (top_left[0] + w, top_left[1] + h)
+
+            cv2.rectangle(image,top_left, bottom_right, 255, 2)
+            cv2.imshow('2D Augmented Reality using Glyphs', image)
+            cv2.waitKey(10)
+    except Exception:
+        print(traceback.format_exc())
+        signal_handler(2, None)

--- a/experiments/camera/glyphtmrs.py
+++ b/experiments/camera/glyphtmrs.py
@@ -1,0 +1,72 @@
+# import the necessary packages
+import numpy as np
+import argparse
+import glob
+import cv2
+ 
+# construct the argument parser and parse the arguments
+ap = argparse.ArgumentParser()
+ap.add_argument("-t", "--template", required=True, help="Path to template image")
+ap.add_argument("-i", "--images", required=True,
+	help="Path to images where template will be matched")
+ap.add_argument("-v", "--visualize",
+	help="Flag indicating whether or not to visualize each iteration")
+args = vars(ap.parse_args())
+ 
+# load the image image, convert it to grayscale, and detect edges
+template = cv2.imread(args["template"])
+template = cv2.cvtColor(template, cv2.COLOR_BGR2GRAY)
+template = cv2.Canny(template, 50, 200)
+(tH, tW) = template.shape[:2]
+cv2.imshow("Template", template)
+
+# loop over the images to find the template in
+for imagePath in glob.glob(args["images"] + "/*.jpg"):
+	# load the image, convert it to grayscale, and initialize the
+	# bookkeeping variable to keep track of the matched region
+	image = cv2.imread(imagePath)
+	gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+	found = None
+ 
+	# loop over the scales of the image
+	for scale in np.linspace(0.2, 1.0, 20)[::-1]:
+		# resize the image according to the scale, and keep track
+		# of the ratio of the resizing
+		resized = cv2.resize(gray, fx=scale, fy=scale)
+		r = gray.shape[1] / float(resized.shape[1])
+ 
+		# if the resized image is smaller than the template, then break
+		# from the loop
+		if resized.shape[0] < tH or resized.shape[1] < tW:
+			break
+        
+        # detect edges in the resized, grayscale image and apply template
+		# matching to find the template in the image
+		edged = cv2.Canny(resized, 50, 200)
+		result = cv2.matchTemplate(edged, template, cv2.TM_CCOEFF)
+		(_, maxVal, _, maxLoc) = cv2.minMaxLoc(result)
+ 
+		# check to see if the iteration should be visualized
+		if args.get("visualize", False):
+			# draw a bounding box around the detected region
+			clone = np.dstack([edged, edged, edged])
+			cv2.rectangle(clone, (maxLoc[0], maxLoc[1]),
+				(maxLoc[0] + tW, maxLoc[1] + tH), (0, 0, 255), 2)
+			cv2.imshow("Visualize", clone)
+			cv2.waitKey(0)
+ 
+		# if we have found a new maximum correlation value, then ipdate
+		# the bookkeeping variable
+		if found is None or maxVal > found[0]:
+			found = (maxVal, maxLoc, r)
+ 
+	# unpack the bookkeeping varaible and compute the (x, y) coordinates
+	# of the bounding box based on the resized ratio
+	(_, maxLoc, r) = found
+	(startX, startY) = (int(maxLoc[0] * r), int(maxLoc[1] * r))
+	(endX, endY) = (int((maxLoc[0] + tW) * r), int((maxLoc[1] + tH) * r))
+ 
+	# draw a bounding box around the detected result and display the image
+	cv2.rectangle(image, (startX, startY), (endX, endY), (0, 0, 255), 2)
+	cv2.imshow("Image", image)
+	cv2.waitKey(0)

--- a/scripts/run-server.sh
+++ b/scripts/run-server.sh
@@ -5,6 +5,7 @@ BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # The executable
 SERVER=$BASE/../code/bin/picopter
+CONFIG=$BASE/../code/configs/auto.json
 
 # Colourful text
 # Red text
@@ -50,7 +51,8 @@ while [ $fails -lt 1 ]; do
 	log_status "Rotating the system logs..."
 	logrotate -f /etc/logrotate.d/picopter.conf
 	log_status "(Re)starting the server..."
-	$SERVER
+    #$SERVER $CONFIG
+	gdb -ex run --args $SERVER $CONFIG
 	error=$?
 	if [ "$error" == "0" ]; then
 		exit 0

--- a/www/index.php
+++ b/www/index.php
@@ -268,6 +268,8 @@
                     <option value="1">Centre of mass</option>
                     <option value="2">Camshift</option>
                     <option value="3">Connected components</option>
+                    <option value="4">Canny glyph detection</option>
+                    <option value="5">Thresholding glyph detection</option>
                     <option value="999">Colour training</option>
                   </select>
                 </div>


### PR DESCRIPTION
Closes #89. Closes #86. There are two types of glyph detection:
* Canny glyph detection
* Thresholding glyph detection

Canny glyph detection uses edge detection to determine contours for potential glyphs. Thresholding glyph detection uses our pre-existing thresholding algorithm to find contours for potential glyphs.

Thresholding glyph detection is faster, but (a) you must know the general colour of the glyph you want to detect (and this colour must form a squre) and (b) generally doesn't pick up glyphs as well, especially if they're closely spaced. Probably not much of an issue out in the field if (a) is ok.

Both methods both make use of template matching (cv::matchTemplate) to perform glyph comparison. Glyph matching at a high level is O(n) on the number of glyphs loaded into the system. Seems to work okay, but it may fail to differentiate glyphs that differ only by e.g. colour.